### PR TITLE
Add npm-debug.log to gitignore correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ settings.js
 public-settings.js
 .next
 node_modules
-npm-debug.log.*
+npm-debug.log
 *.sh


### PR DESCRIPTION
I noticed that `.gitignore` wasn't ignoring `npm-debug.log`. So this fixes that.